### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See the [Usage](#usage) section for examples.
 
 ### Installation
 
-##### Cocoapods
+##### CocoaPods
 
 Add the following to your Podfile:
 
@@ -39,7 +39,7 @@ And run:
 $ pod install
 ```
 
-[Here][cocoapod-swift-help] is a helpful article about setting up your project to use Cocoapods with Swift.
+[Here][cocoapod-swift-help] is a helpful article about setting up your project to use CocoaPods with Swift.
 
 ##### Import as an embedded framework
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
